### PR TITLE
add overflow to names in results aside

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 # Juan, George, Joe, James, Evan
 [![CircleCI](https://circleci.com/gh/EvanSays/Quizzam/tree/master.svg?style=svg)](https://circleci.com/gh/EvanSays/Quizzam/tree/master)
 
+## Setup
 
 ## Screenshots
 

--- a/src/components/styles/QuizResultsAside.scss
+++ b/src/components/styles/QuizResultsAside.scss
@@ -54,6 +54,9 @@
 
 .names {
   padding: 20px;
+  padding: 20px;
+  overflow-y: scroll;
+  height: 200px;
   p {
     padding-left: 20px;
     line-height: 11px;


### PR DESCRIPTION
## Issue (if no issue delete question)

## Description?
- Usernames in the results aside are now limited to 200px in height.
## What should we test?

## How do you feel?
![](gifylink)

## Notes
